### PR TITLE
Fix setup-helper usage

### DIFF
--- a/kvlists.release-info
+++ b/kvlists.release-info
@@ -5,3 +5,4 @@
 (release "1.0.3")
 (release "1.0.4")
 (release "1.0.5")
+(release "1.0.6")

--- a/kvlists.setup
+++ b/kvlists.setup
@@ -2,4 +2,4 @@
 
 (setup-shared-extension-module
  'kvlists
- '(version "1.0.5"))
+ '(version "1.0.6"))

--- a/kvlists.setup
+++ b/kvlists.setup
@@ -1,4 +1,4 @@
-(include "setup-helper")
+(use setup-helper-mod)
 
 (setup-shared-extension-module
  'kvlists


### PR DESCRIPTION
[Today's Salmonella build](https://salmonella-linux-x86-64.call-cc.org/master-debugbuild/gcc/linux/x86-64/2016/09/03/yesterday-diff/log2/install/kvlists.html) shows that kvlists fails to install with setup-helper 2.0.

Using `(include "setup-helper")` to load setup-helper is deprecated, and has been for a very long time. See also [this thread on chicken-users](http://lists.gnu.org/archive/html/chicken-users/2016-09/msg00004.html)

This PR simply uses the new style `(use setup-helper-mod)` and adds a 1.0.6 release. Please check if the tag is included in the pull request (I don't know enough about github to know if this is done or not).
